### PR TITLE
Add .gitignore for OS/editor files and binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# OS-specific files
+.DS_Store
+.AppleDouble
+.LSOverride
+Thumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+*~
+
+# Editor directories and files
+.vscode/
+.idea/
+*.swp
+
+# Binary assets (use Git LFS or ignore)
+*.jpg
+*.jpeg
+*.png
+*.gif
+*.bmp
+*.pdf
+*.docx
+*.pptx
+*.glb


### PR DESCRIPTION
## Summary
- add `.gitignore` to ignore common OS/editor files
- ignore large binary assets and mention Git LFS use

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b59044bf4832daeff08989ddc218b