### PR TITLE
Improve alt text for product images

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,7 +187,7 @@
       <!-- Bild: Frau mit Wanderstock -->
       <div>
         <div class="relative">
-          <img src="resized_rei1.jpeg" alt="Frau mit Wanderstock" class="w-full h-auto rounded-b-none">
+          <img src="resized_rei1.jpeg" alt="Hiker using SummitDrive trekking poles on mountain trail" class="w-full h-auto rounded-b-none">
            
           <!-- ⭐ Bewertung -->
   <div class="absolute bottom-20 left-3 flex items-center gap-1 text-yellow-400 text-sm">
@@ -213,7 +213,7 @@
 
       <div>
         <div class="relative">
-          <img src="resized_rei2.jpg" alt="Frau mit Wanderstock" class="w-full h-auto rounded-b-none">
+          <img src="resized_rei2.jpg" alt="Trail runner with TrekForce X poles on rocky path" class="w-full h-auto rounded-b-none">
 
             <!-- ⭐ Bewertung -->
   <div class="absolute bottom-20 left-3 flex items-center gap-1 text-yellow-400 text-sm">
@@ -239,7 +239,7 @@
 
       <div>
         <div class="relative">
-          <img src="resized_rei3.jpeg" alt="Frau mit Wanderstock" class="w-full h-auto rounded-b-none">
+          <img src="resized_rei3.jpeg" alt="Woman holding LexiStock Pro poles in alpine scenery" class="w-full h-auto rounded-b-none">
           
             <!-- ⭐ Bewertung -->
   <div class="absolute bottom-20 left-3 flex items-center gap-1 text-yellow-400 text-sm">
@@ -265,7 +265,7 @@
 
       <div>
         <div class="relative">
-          <img src="resized_rei4.jpeg" alt="Frau mit Wanderstock" class="w-full h-auto rounded-b-none">
+          <img src="resized_rei4.jpeg" alt="Man hiking with TrailGrip poles along grassy hillside" class="w-full h-auto rounded-b-none">
           
             <!-- ⭐ Bewertung -->
   <div class="absolute bottom-20 left-3 flex items-center gap-1 text-yellow-400 text-sm">
@@ -291,7 +291,7 @@
 
       <div>
         <div class="relative">
-          <img src="resized_rei5.jpeg" alt="Frau mit Wanderstock" class="w-full h-auto rounded-b-none">
+          <img src="resized_rei5.jpeg" alt="Walker resting on PowerStep 360 poles during a break" class="w-full h-auto rounded-b-none">
           
             <!-- ⭐ Bewertung -->
   <div class="absolute bottom-20 left-3 flex items-center gap-1 text-yellow-400 text-sm">
@@ -316,7 +316,7 @@
 
       <div>
         <div class="relative">
-          <img src="resized_rei6.jpeg" alt="Frau mit Wanderstock" class="w-full h-auto rounded-b-none">
+          <img src="resized_rei6.jpeg" alt="PeakMotion poles planted in snowy terrain" class="w-full h-auto rounded-b-none">
           
           <!-- ⭐ Bewertung -->
   <div class="absolute bottom-20 left-3 flex items-center gap-1 text-yellow-400 text-sm">


### PR DESCRIPTION
## Summary
- refine alt text for the six product images in index.html

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684b5925fe28832d9df7c384ee85bc3e