### PR TITLE
Stop repeating 3D animation on click

### DIFF
--- a/index.html
+++ b/index.html
@@ -475,11 +475,22 @@ faders.forEach(el => appearOnScroll.observe(el));
     }
   });
 
+  let animationFinished = false;
+
   modelViewer.addEventListener('click', () => {
-    if (modelViewer.availableAnimations && modelViewer.availableAnimations.length > 0) {
+    if (animationFinished) {
+      modelViewer.currentTime = 0;
+      modelViewer.pause();
+      animationFinished = false;
+    } else if (modelViewer.paused && modelViewer.availableAnimations && modelViewer.availableAnimations.length > 0) {
       modelViewer.currentTime = 0;
       modelViewer.play({repetitions: 1});
     }
+  });
+
+  modelViewer.addEventListener('finished', () => {
+    animationFinished = true;
+    modelViewer.pause();
   });
 </script>
 


### PR DESCRIPTION
## Summary
- prevent `model-viewer` from restarting its animation when clicked again
- clicking after the animation has ended now rewinds to the first frame and pauses

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684bf911d398832d810636e1e60531c1