### PR TITLE
Disable 3D model zoom on scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,6 +116,7 @@
     alt="3D Wanderstock"
     auto-rotate
     camera-controls
+    disable-zoom
     class="w-full h-full max-w-[100%] max-h-[100%] object-contain">
   </model-viewer>
 </div>
@@ -497,6 +498,13 @@ faders.forEach(el => appearOnScroll.observe(el));
   modelViewer.addEventListener('finished', () => {
     animationFinished = true;
     modelViewer.pause();
+  });
+
+  // Allow page scrolling when mouse wheel is used over the model
+  modelViewer.addEventListener('wheel', (event) => {
+    if (modelViewer.hasAttribute('disable-zoom')) {
+      window.scrollBy(0, event.deltaY);
+    }
   });
 </script>
 


### PR DESCRIPTION
## Summary
- disable zooming in `<model-viewer>`
- forward scroll wheel events so the page scrolls normally

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68515ee72e84832d98a6a35b80080585