### PR TITLE
Limit model rotation

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,6 +117,8 @@
     auto-rotate
     camera-controls
     disable-zoom
+    min-camera-orbit="-60deg 15deg auto"
+    max-camera-orbit="60deg 135deg auto"
     class="w-full h-full max-w-[100%] max-h-[100%] object-contain">
   </model-viewer>
 </div>


### PR DESCRIPTION
## Summary
- restrict the `<model-viewer>` rotation range to 60° around the initial position

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685160ef7298832d9c37ee560bf35564