### PR TITLE
Start 3D view from front

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,8 +135,8 @@
     disable-zoom
 
     camera-orbit="0deg 90deg auto"
-    min-camera-orbit="-45deg 135deg auto"
-    max-camera-orbit="45deg -45deg auto"
+    min-camera-orbit="0deg 45deg auto"
+    max-camera-orbit="0deg 135deg auto"
 
     class="w-full h-full max-w-[100%] max-h-[100%] object-contain">
   </model-viewer>
@@ -460,17 +460,18 @@ faders.forEach(el => appearOnScroll.observe(el));
 <script>
   const modelViewer = document.getElementById('hikingModel');
 
-  let pitch = 0;
+  // Start the model from a front-facing view
+  let pitch = 90;
   let direction = 1;
   let verticalAnimId;
 
   function animatePitch() {
     pitch += 0.5 * direction;
-    if (pitch >= 45) {
-      pitch = 45;
+    if (pitch >= 135) {
+      pitch = 135;
       direction = -1;
-    } else if (pitch <= -45) {
-      pitch = -45;
+    } else if (pitch <= 45) {
+      pitch = 45;
       direction = 1;
     }
     modelViewer.cameraOrbit = `0deg ${pitch}deg auto`;


### PR DESCRIPTION
## Summary
- start the model-viewer camera at a front-facing position
- adjust vertical rotation range to maintain front view

## Testing
- `npm install -g @gltf-transform/cli`
- `assimp info hiking_poles3.glb`


------
https://chatgpt.com/codex/tasks/task_e_685176cde8a0832d9b8719100902af52