### PR TITLE
Add 4K font scaling rule

### DIFF
--- a/style.css
+++ b/style.css
@@ -276,6 +276,12 @@ body {
   }
 }
 
+@media (min-width: 1920px) {
+  html {
+    font-size: 24px;
+  }
+}
+
 /* Zoom effect for product images */
 .product-image-container {
   overflow: hidden;


### PR DESCRIPTION
## Summary
- add CSS rule for screens wider than 1920px to keep text legible on 4K displays

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68517c40a640832d98f434114449ca02