### PR TITLE
Keep binary assets in repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,13 +12,3 @@ $RECYCLE.BIN/
 .idea/
 *.swp
 
-# Binary assets (use Git LFS or ignore)
-*.jpg
-*.jpeg
-*.png
-*.gif
-*.bmp
-*.pdf
-*.docx
-*.pptx
-*.glb

--- a/README.md
+++ b/README.md
@@ -23,3 +23,7 @@ The page expects several images and a glTF binary (`.glb`) model in the project 
 - `hiking_poles.glb` (3D hiking pole model)
 
 These files must be present for the web page to render correctly.
+
+## Binary Assets
+
+All images, PDFs, DOCX, PPTX files and the `.glb` 3D model are stored directly in this repository. The total project size is under 100&nbsp;MB, so using Git LFS is unnecessary. Keeping the assets in Git allows the page to work out-of-the-box when cloning the repo.


### PR DESCRIPTION
## Summary
- clean up `.gitignore` by removing rules that excluded images and docs
- document why the repository keeps binary assets in Git

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68518871f9dc832da285ed4e80325dfd