### PR TITLE
Fix duplicate slide container ID

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@
 </script>
 
   <section class="relative w-full h-screen overflow-hidden">
-  <div id="slides" class="w-full h-full relative">
+  <div id="model-slides" class="w-full h-full relative">
 
   <!-- Zentrum: 3D-Modell -->
   <model-viewer


### PR DESCRIPTION
## Summary
- rename second `<div id="slides">` in 3D model section to `model-slides`

## Testing
- `curl -I http://localhost:8000/index.html`


------
https://chatgpt.com/codex/tasks/task_e_6851889251dc832dbcc5b052e06ac9ea