### PR TITLE
Enable zoom on 3D model

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repository contains a sample responsive web page demonstrating product pres
 2. Make sure all image files and the `hiking_poles.glb` 3D model remain in the same directory as `index.html`.
 3. Open `index.html` in your web browser to view the page. For best results you can serve the files using a local web server.
 
+4. The 3D model loads zoomed in. Adjust the zoom using your mouse wheel or pinch gestures on touch devices.
 ## Required Assets
 
 The page expects several images and a glTF binary (`.glb`) model in the project root:

--- a/index.html
+++ b/index.html
@@ -131,11 +131,10 @@
     src="hiking_poles3.glb"
     alt="3D Wanderstock"
     camera-controls
-    disable-zoom
 
-    camera-orbit="0deg 90deg auto"
-    min-camera-orbit="-60deg 60deg auto"
-    max-camera-orbit="60deg 120deg auto"
+    camera-orbit="0deg 90deg 3.5m"
+    min-camera-orbit="-60deg 60deg 2.5m"
+    max-camera-orbit="60deg 120deg 5m"
 
     class="w-full h-full max-w-[100%] max-h-[100%] object-contain">
   </model-viewer>
@@ -508,11 +507,8 @@ faders.forEach(el => appearOnScroll.observe(el));
 
   // Allow page scrolling when mouse wheel is used over the model
   modelViewer.addEventListener('wheel', (event) => {
-    if (modelViewer.hasAttribute('disable-zoom')) {
-      window.scrollBy(0, event.deltaY);
-    }
+    window.scrollBy(0, event.deltaY);
   });
-</script>
 
 <script>
   const toggleButton = document.getElementById('menu-toggle');


### PR DESCRIPTION
## Summary
- allow zooming the 3D model by removing the `disable-zoom` flag
- adjust mouse wheel handler accordingly
- document zoom capability in README
- load model zoomed in by default

## Testing
- `pip install open3d -q`
- `python3 - <<'PY'
import open3d as o3d
mesh=o3d.io.read_triangle_mesh('hiking_poles3.glb')
print('n_verts',len(mesh.vertices))
PY
`

------
https://chatgpt.com/codex/tasks/task_e_6851899088b8832db167a89fb98d88c6