### PR TITLE
Fix sticky header logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -524,10 +524,10 @@ faders.forEach(el => appearOnScroll.observe(el));
 
 <script>
   const siteHeader = document.getElementById('site-header');
-  let lastScrollY = window.scrollY;
+  let lastScrollY = window.pageYOffset;
 
   window.addEventListener('scroll', () => {
-    const current = window.scrollY;
+    const current = window.pageYOffset;
     if (current < lastScrollY || current <= 0) {
       siteHeader.classList.remove('hide');
     } else if (current > lastScrollY) {

--- a/style.css
+++ b/style.css
@@ -42,7 +42,7 @@ body {
 
 /* Header visibility on scroll */
 #site-header {
-  position: sticky;
+  position: fixed;
   top: 0;
   z-index: 50;
   transition: transform 0.3s ease;


### PR DESCRIPTION
## Summary
- make header `position: fixed` instead of `sticky`
- use `pageYOffset` in JS to check scroll position

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852bd484f20832da5dfc3e267d46d64