### PR TITLE
Center hero images for different screen formats

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,13 +58,13 @@
 <section class="relative w-full h-screen overflow-hidden">
   <div id="slides" class="w-full h-full relative">
     <div class="slide absolute inset-0 transition-opacity duration-700 opacity-100">
-        <img src="Bilder/AthletinWanderstock.jpeg" class="object-top object-cover w-full h-full" alt="Slide 1">
+        <img src="Bilder/AthletinWanderstock.jpeg" class="hero-image" alt="Slide 1">
     </div>
     <div class="slide absolute inset-0 transition-opacity duration-700 opacity-0">
-        <img src="Bilder/AthletWanderstock.jpeg" class="object-top object-cover w-full h-full" alt="Slide 2">
+        <img src="Bilder/AthletWanderstock.jpeg" class="hero-image" alt="Slide 2">
     </div>
     <div class="slide absolute inset-0 transition-opacity duration-700 opacity-0">
-        <img src="Bilder/KindWanderstock.jpeg" class="object-top object-cover w-full h-full" alt="Slide 3">
+        <img src="Bilder/KindWanderstock.jpeg" class="hero-image" alt="Slide 3">
     </div>
   </div>
 

--- a/style.css
+++ b/style.css
@@ -60,3 +60,21 @@ body {
   letter-spacing: 0.05em;
 }
 
+.hero-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: 50% 50%;
+}
+
+@media (orientation: landscape) {
+  .hero-image {
+    object-position: center 50%;
+  }
+}
+
+@media (orientation: portrait) {
+  .hero-image {
+    object-position: 50% center;
+  }
+}


### PR DESCRIPTION
## Summary
- align hero slideshow images using a new `hero-image` class
- center background images vertically on wide screens and horizontally on tall screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6855b7ad3c28832d8d373086634253ac