### PR TITLE
Fix hero image cropping on widescreens

### DIFF
--- a/style.css
+++ b/style.css
@@ -69,7 +69,8 @@ body {
 
 @media (orientation: landscape) {
   .hero-image {
-    object-position: center 50%;
+    object-fit: contain;
+    object-position: center;
   }
 }
 


### PR DESCRIPTION
## Summary
- make hero images fully visible on large landscape screens

## Testing
- `file Bilder/AthletinWanderstock.jpeg`

------
https://chatgpt.com/codex/tasks/task_e_6855d2d93fd4832db582c97f48558f8e