### PR TITLE
Fix hero image orientation

### DIFF
--- a/style.css
+++ b/style.css
@@ -67,18 +67,6 @@ body {
 .hero-image {
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  object-fit: contain;
   object-position: top;
-}
-
-@media (orientation: landscape) {
-  .hero-image {
-    object-position: center 50%;
-  }
-}
-
-@media (orientation: portrait) {
-  .hero-image {
-    object-position: 50% center;
-  }
 }


### PR DESCRIPTION
## Summary
- stop distortion of hero images
- orient hero images to top without centering rules

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855f1f18a84832db90b8531e4122813