### PR TITLE
Fix hero image stretch

### DIFF
--- a/style.css
+++ b/style.css
@@ -67,6 +67,6 @@ body {
 .hero-image {
   width: 100%;
   height: 100%;
-  object-fit: fill;
+  object-fit: cover;
   object-position: top;
 }


### PR DESCRIPTION
## Summary
- use `object-fit: cover` for hero images so they fill the slides and keep the upper portion visible

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855f3d9d70c832d866c7667a5c60546